### PR TITLE
Add support for AZURE_FEDERATED_TOKEN_FILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ AZURE_FEDERATED_TOKEN=<federatedJWT>
 AZURE_TENANT_ID=<tenantId>
 ```
 
+If you use federated OIDC with [Azure Workload Identity](https://github.com/Azure/azure-workload-identity) you don't
+have to set any ENVs as they will get injected automatically.
+
 If the above are not set then authentication falls back to managed service identities and the MSI endpoint is
 attempted to be contacted which will work in various Azure contexts such as App Service and Azure Kubernetes Service
 where the MSI endpoint will authenticate the MSI context the service is running under.


### PR DESCRIPTION
Addendum for #10. This is needed for Azure Workload Identity.

Closes #8 